### PR TITLE
Update cephadm plans

### DIFF
--- a/ceph/README.md
+++ b/ceph/README.md
@@ -12,6 +12,13 @@ Using Cephadm:
 https://docs.ceph.com/docs/master/cephadm/
 
 
+Create a Ceph cluster:
 ```
 # kcli create plan -f ceph_cluster.yml
 ```
+
+Create a Ceph cluster for development use:
+```
+kcli create plan -f ceph_cluster.yml -P ceph_dev_folder=/home/me/Code/ceph
+```
+The parameter <<ceph_dev_folder>> must point to the folder where your Ceph code lives.

--- a/ceph/README.md
+++ b/ceph/README.md
@@ -1,16 +1,15 @@
 Plans to deploy Ceph clusters:
 
 
-Using Ceph Ansible:
+**Using Ceph Ansible:**
 https://docs.ceph.com/ceph-ansible/master/
 
 ```
 # kcli create plan -f upstream.yml
 ```
 
-Using Cephadm:
+**Using Cephadm:**
 https://docs.ceph.com/docs/master/cephadm/
-
 
 Create a Ceph cluster:
 ```
@@ -22,3 +21,15 @@ Create a Ceph cluster for development use:
 kcli create plan -f ceph_cluster.yml -P ceph_dev_folder=/home/me/Code/ceph
 ```
 The parameter <<ceph_dev_folder>> must point to the folder where your Ceph code lives.
+
+
+**Using Rook Operator:** 
+https://rook.github.io/docs/rook/master/
+
+Create a Ceph cluster:
+```
+# kcli create plan -f ./k8s/kubernetes.yml
+```
+
+A ceph toolbox is also deployed. It can be run using the command "c" in the k8 master vm. 
+

--- a/ceph/bootstrap-cluster.sh
+++ b/ceph/bootstrap-cluster.sh
@@ -1,14 +1,22 @@
 export PATH=/root/bin:$PATH
 mkdir /root/bin
-cd /root/bin
-curl --silent --remote-name --location https://raw.githubusercontent.com/ceph/ceph/master/src/cephadm/cephadm
-chmod +x cephadm
+{% if ceph_dev_folder is defined %}
+  cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
+{% else %}
+  cd /root/bin
+  curl --silent --remote-name --location https://raw.githubusercontent.com/ceph/ceph/master/src/cephadm/cephadm
+{% endif %}
+chmod +x /root/bin/cephadm
 mkdir -p /etc/ceph
 mon_ip=$(ifconfig eth0  | grep 'inet ' | awk '{ print $2}')
-cephadm bootstrap --mon-ip $mon_ip --allow-fqdn-hostname --initial-dashboard-password {{ admin_password }}
+{% if ceph_dev_folder is defined %}
+  cephadm bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/{{ ceph_dev_folder }}
+{% else %}
+  cephadm bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate
+{% endif %}
 fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
 {% for number in range(1, nodes) %}
-  ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@{{ prefix }}-node-0{{ number }}
-  cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch host add {{ prefix }}-node-0{{ number }}.{{domain}}
+  ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@{{ prefix }}-node-0{{ number }}.{{ domain }}
+  cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch host add {{ prefix }}-node-0{{ number }}.{{ domain }}
 {% endfor %}
 cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch apply osd --all-available-devices

--- a/ceph/bootstrap-cluster.sh
+++ b/ceph/bootstrap-cluster.sh
@@ -6,7 +6,7 @@ mkdir /root/bin
   cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
 {% else %}
   cd /root/bin
-  curl --silent --remote-name --location https://raw.githubusercontent.com/ceph/ceph/master/src/cephadm/cephadm
+  curl --silent --remote-name --location https://github.com/ceph/ceph/raw/quincy/src/cephadm/cephadm
 {% endif %}
 chmod +x /root/bin/cephadm
 mkdir -p /etc/ceph

--- a/ceph/bootstrap-cluster.sh
+++ b/ceph/bootstrap-cluster.sh
@@ -6,7 +6,7 @@ mkdir /root/bin
   cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
 {% else %}
   cd /root/bin
-  curl --silent --remote-name --location https://github.com/ceph/ceph/raw/quincy/src/cephadm/cephadm
+  curl --silent --output cephadm --location https://raw.githubusercontent.com/ceph/ceph/main/src/cephadm/cephadm.py
 {% endif %}
 chmod +x /root/bin/cephadm
 mkdir -p /etc/ceph

--- a/ceph/bootstrap-cluster.sh
+++ b/ceph/bootstrap-cluster.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export PATH=/root/bin:$PATH
 mkdir /root/bin
 {% if ceph_dev_folder is defined %}

--- a/ceph/ceph_cluster.yml
+++ b/ceph/ceph_cluster.yml
@@ -29,12 +29,13 @@ parameters:
  {% if ceph_dev_folder is defined %}
  sharedfolders: [{{ ceph_dev_folder }}]
  {% endif %}
+ files:
+  - bootstrap-cluster.sh
  cmds:
  - dnf -y install python3 chrony lvm2 podman
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}
- scripts:
-  - bootstrap-cluster.sh
+ - bash /root/bootstrap-cluster.sh
  {% endif %}
 {% endfor %}

--- a/ceph/ceph_cluster.yml
+++ b/ceph/ceph_cluster.yml
@@ -4,20 +4,21 @@ parameters:
  network: default
  domain: cephlab.com
  prefix: ceph
- numcpus: 2
- memory: 4096
- image: centos8
+ numcpus: 1
+ memory: 2048
+ image: fedora34
  notify: false
  admin_password: password
  disks:
- - 150
- - 150
+ - 15
+ - 5
 
 {% for number in range(0, nodes) %}
 {{ prefix }}-node-0{{ number }}:
  image: {{ image }}
  numcpus: {{ numcpus }}
  memory: {{ memory }}
+ reserveip: true
  reservedns: true
  sharedkey: true
  domain: {{ domain }}
@@ -25,8 +26,11 @@ parameters:
   - {{ network }}
  disks: {{ disks }}
  pool: {{ pool }}
+ {% if ceph_dev_folder is defined %}
+ sharedfolders: [{{ ceph_dev_folder }}]
+ {% endif %}
  cmds:
- - yum -y install python3 chrony lvm2 podman
+ - dnf -y install python3 chrony lvm2 podman
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}

--- a/ceph/k8s/kubernetes.repo
+++ b/ceph/k8s/kubernetes.repo
@@ -1,0 +1,6 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0

--- a/ceph/k8s/kubernetes.sh
+++ b/ceph/k8s/kubernetes.sh
@@ -1,0 +1,58 @@
+{% if sdn == 'calico' %}
+CIDR="192.168.0.0/16"
+{% else %} 
+CIDR="10.244.0.0/16"
+{% endif %} 
+{% if masters > 1 %}
+kubeadm init --control-plane-endpoint "{{ prefix }}-master.{{ network }}:6443" --pod-network-cidr $CIDR --upload-certs
+{% else %}
+kubeadm init --pod-network-cidr $CIDR
+{% endif %}
+cp /etc/kubernetes/admin.conf /root/
+chown root:root /root/admin.conf
+export KUBECONFIG=/root/admin.conf
+echo "export KUBECONFIG=/root/admin.conf" >>/root/.bashrc
+kubectl taint nodes --all node-role.kubernetes.io/master-
+{% if sdn == 'flannel' %}
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+{% elif sdn == 'weavenet' %}
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=`kubectl version | base64 | tr -d '\n'`"
+{% elif sdn == 'calico' %}
+kubectl apply -f https://docs.projectcalico.org/v3.9/manifests/calico.yaml
+{% elif sdn == 'canal' %}
+kubectl apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/canal/rbac.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+{% elif sdn == 'romana' %}
+kubectl apply -f https://raw.githubusercontent.com/romana/romana/master/containerize/specs/romana-kubeadm.yml
+{% endif %} 
+mkdir -p /root/.kube
+cp -i /etc/kubernetes/admin.conf /root/.kube/config
+chown root:root /root/.kube/config
+IP=`ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'`
+TOKEN=`kubeadm token create --ttl 0`
+HASH=`openssl x509 -in /etc/kubernetes/pki/ca.crt -noout -pubkey | openssl rsa -pubin -outform DER 2>/dev/null | sha256sum | cut -d' ' -f1`
+CMD="kubeadm join $IP:6443 --token $TOKEN --discovery-token-ca-cert-hash sha256:$HASH"
+
+sleep 60
+
+{% if masters > 1 %}
+{% for number in range(1,masters) %}
+CERTKEY=$(grep certificate-key /var/log/messages | head -1 | sed 's/.*certificate-key \(.*\)/\1/')
+MASTERCMD="$CMD --control-plane --certificate-key $CERTKEY"
+echo $MASTERCMD > /root/mastercmd.sh
+ssh-keyscan -H {{ prefix }}-master-0{{ number }} >> ~/.ssh/known_hosts 
+scp /etc/kubernetes/admin.conf root@{{ prefix }}-master-0{{ number }}:/etc/kubernetes/
+echo ssh root@{{ prefix }}-master-0{{ number }} $MASTERCMD > /root/{{ prefix }}-master-0{{ number }}.log 2>&1
+ssh root@{{ prefix }}-master-0{{ number }} $MASTERCMD >> /root/{{ prefix }}-master-0{{ number }}.log 2>&1
+scp /etc/kubernetes/admin.conf {{ prefix }}-master-0{{ number }}:/root
+ssh {{ prefix }}-master-0{{ number }} mkdir -p /root/.kube
+ssh {{ prefix }}-master-0{{ number }} cp -i /root/admin.conf /root/.kube/config
+ssh {{ prefix }}-master-0{{ number }} chown root:root /root/.kube/config
+{% endfor %}
+{% endif %}
+
+{% for number in range(0,workers) %}
+ssh-keyscan -H {{ prefix }}-worker-0{{ number }} >> ~/.ssh/known_hosts
+scp /etc/kubernetes/admin.conf root@{{ prefix }}-worker-0{{ number }}:/etc/kubernetes/
+ssh root@{{ prefix }}-worker-0{{ number }} ${CMD} > /root/{{ prefix }}-worker-0{{ number }}.log 2>&1
+{% endfor %}

--- a/ceph/k8s/kubernetes.yml
+++ b/ceph/k8s/kubernetes.yml
@@ -1,0 +1,70 @@
+parameters:
+ masters: 1
+ workers: 2
+ domain: rook
+ pool: default
+ network: default
+ prefix: k8s
+ sdn: flannel
+ master_memory: 6144
+ node_memory: 4096
+ image: centos7
+
+{% if masters > 1 %}
+{{ prefix }}-master:
+ type: loadbalancer
+ nets:
+ - name: {{ network }}
+ ports:
+ - 6443
+ vms:
+{% for number in range(0, masters) %}
+  - {{prefix}}-master-0{{ number }}
+{% endfor %}
+{%endif %}
+
+{% for number in range(0, masters) %}
+{{prefix}}-master-0{{ number }}:
+ image: {{ image }}
+ numcpus: 2
+ memory: {{ master_memory }}
+ reservedns: true
+ sharedkey: true
+ domain: {{ domain }}
+ nets:
+  - {{ network }}
+ disks:
+  - size: 50
+  - size: 50
+ pool: {{ pool }}
+ files:
+  - path: /etc/yum.repos.d/kubernetes.repo
+    origin: kubernetes.repo
+ scripts:
+  - pre.sh
+{% if number == 0 %}
+  - kubernetes.sh
+  - rook.sh
+{% endif %}
+{% endfor %}
+
+{% for number in range(0, workers) %}
+{{prefix }}-worker-0{{ number }}:
+ image: {{ image }}
+ numcpus: 2
+ memory: {{ node_memory }}
+ reservedns: true
+ sharedkey: true
+ domain: {{ domain }}
+ nets:
+  - {{ network }}
+ disks:
+  - size: 50
+  - size: 50
+ pool: {{ pool }}
+ files:
+  - path: /etc/yum.repos.d/kubernetes.repo
+    origin: kubernetes.repo
+ scripts:
+  - pre.sh
+{% endfor %}

--- a/ceph/k8s/pre.sh
+++ b/ceph/k8s/pre.sh
@@ -1,0 +1,12 @@
+yum -y install wget git
+wget -P /root/ https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+mv /root/jq-linux64 /usr/bin/jq
+chmod u+x /usr/bin/jq
+echo net.bridge.bridge-nf-call-iptables=1 >> /etc/sysctl.d/99-sysctl.conf
+sysctl -p
+setenforce 0
+sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
+yum install -y docker kubelet kubectl kubeadm
+sed -i "s/--selinux-enabled //" /etc/sysconfig/docker
+systemctl enable docker && systemctl start docker
+systemctl enable kubelet && systemctl start kubelet

--- a/ceph/k8s/rook.sh
+++ b/ceph/k8s/rook.sh
@@ -1,0 +1,11 @@
+kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/crds.yaml
+kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/common.yaml
+kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/operator.yaml
+kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/cluster.yaml
+# Toolbox
+kubectl create -f https://raw.githubusercontent.com/rook/rook/master/cluster/examples/kubernetes/ceph/toolbox.yaml
+kubectl -n rook-ceph rollout status deploy/rook-ceph-tools
+echo "alias c='kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash'" >> /root/.bashrc
+source /root/.bashrc
+# Report status (journalctl -t cloud.init)
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph -s


### PR DESCRIPTION
This change makes the current plan to deploy Ceph clusters using cephadm more flexible, allowing also to create clusters for development purposes when it is used the parameter "ceph_dev_folder" pointing to your Ceph Code folder.